### PR TITLE
Add Dev-Env Support for OSX（来自遥远某处的另一声喵叫

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,12 @@
+# Universal
 dist
+.configured
+
+# OSX
 .DS_Store
+
+# Windows
+thumbs.db
+
+# Linux - Plasma
+.directory

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "bruno-dias.ink",
+        "sumneko.lua",
+        "slevesque.shader"
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,19 @@
                 "--fused"
             ],
             "preLaunchTask": "Build"
+        },
+        {
+            "name": "Launch_OSX",
+            "request": "launch",
+            "type": "lua-local",
+            "program": {
+                "command": "/Applications/love.app/Contents/MacOS/love"
+            },
+            "args": [
+                "dist",
+                "--fused"
+            ],
+            "preLaunchTask": "Build"
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,25 +5,19 @@
             "request": "launch",
             "type": "lua-local",
             "program": {
-                "command": "love"
+                "command": "bash"
             },
-            "args": [
-                "dist",
-                "--fused"
-            ],
-            "preLaunchTask": "Build"
-        },
-        {
-            "name": "Launch_OSX",
-            "request": "launch",
-            "type": "lua-local",
-            "program": {
-                "command": "/Applications/love.app/Contents/MacOS/love"
+            "osx": {
+                "env": {
+                    "LOVE_EXECUTABLE": "/Applications/love.app/Contents/MacOS/love"
+                }
             },
-            "args": [
-                "dist",
-                "--fused"
-            ],
+            "linux": {
+                "env": {
+                    "LOVE_EXECUTABLE": "love"
+                }
+            },
+            "args": ["-c \"\\\"${LOVE_EXECUTABLE}\\\" dist --fused\""],
             "preLaunchTask": "Build"
         }
     ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,34 @@
     "files.associations": {
         "*.yconf": "yuescript",
         "*.lconf": "lua"
+    },
+    "terminal.integrated.profiles.linux": {
+        "bash": {
+            "path": "bash",
+            "args": ["-c", "if ! [ -f \".configured\" ]; then echo -e \"\\n\\033[1m    Hello, Nyaacinth here! If you saw this message, maybe you just cloned Dreamless repo and opened it with VSCode. Here's something need to be noticed:\\n\\n    1) Except the libraries, this project is mostly written in yuescript (a dialect to moonscript), and there's no extension support in VSCode. For syntax-highlighting, you need to download https://github.com/Nyaacinth/Iroiro/raw/main/yuescript_syntax.json and package it yourself.\\n\\n    2) This is a personal project, so if you decided to make a contribution now, there is a high probability that the contribution won't be accepted.\\n\\n    3) This is a derivative work of Dream Diary, and due to that the goal of this project may be slightly different from your thinking.\\n\"; read -n 1 -s -r -p \"Press any key to continue...\"; clear; echo \"true\" > \".configured\"; fi; exec $SHELL"]
+        }
+    },
+    "terminal.integrated.profiles.osx": {
+        "bash": {
+            "path": "bash",
+            "args": ["-c", "if ! [ -f \".configured\" ]; then echo -e \"\\n\\033[1m    Hello, Nyaacinth here! If you saw this message, maybe you just cloned Dreamless repo and opened it with VSCode. Here's something need to be noticed:\\n\\n    1) Except the libraries, this project is mostly written in yuescript (a dialect to moonscript), and there's no extension support in VSCode. For syntax-highlighting, you need to download https://github.com/Nyaacinth/Iroiro/raw/main/yuescript_syntax.json and package it yourself.\\n\\n    2) This is a personal project, so if you decided to make a contribution now, there is a high probability that the contribution won't be accepted.\\n\\n    3) This is a derivative work of Dream Diary, and due to that the goal of this project may be slightly different from your thinking.\\n\"; read -n 1 -s -r -p \"Press any key to continue...\"; clear; echo \"true\" > \".configured\"; fi; exec $SHELL"]
+        }
+    },
+    "terminal.integrated.profiles.windows": {
+        "PowerShell": {
+            "source": "PowerShell",
+            "args": ["-c", "echo \"Build in Windows is not supported, please consider using WSL instead\"; Start-Sleep -s 5"]
+        },
+        "Command Prompt": {
+            "path": [
+                "${env:windir}\\Sysnative\\cmd.exe",
+                "${env:windir}\\System32\\cmd.exe"
+            ],
+            "args": ["/C", "echo \"Build in Windows is not supported, please consider using WSL instead\"; timeout /T 5 /NOBREAK"]
+        },
+        "Git Bash": {
+            "source": "Git Bash",
+            "args": ["-c", "echo \"Build in Windows is not supported, please consider using WSL instead\"; sleep 5"]
+        }
     }
 }

--- a/build_hooks/build_data
+++ b/build_hooks/build_data
@@ -5,7 +5,9 @@ if [ -d "data" ] && [ ! "$(ls -A data)" = "" ]; then
             if [ -f "${filename}" ]; then
                 if [ "${filename##*.}" = "yconf" ]; then
                     set +e
-                        cat "${filename}" | sed '1i\{' | sed '$a\}' | yue -- > "${filename%.*}.lua"
+                        cat "${filename}" | sed '1i\
+                            {' | sed '$a\
+                            }' | yue -- > "${filename%.*}.lua"
                         if [ ! $? = 0 ]; then
                             echo "Fail to build: data/${filename}"
                             rm "${filename%.*}.lua"


### PR DESCRIPTION
## 更改的文件

- `.gitignore` 增加了一个忽略文件 `.DS_Store`: Desktop Services Store（OSX目录自定义属性配置）

- `build_data` 缩进改进，以修复在OSX上build时出现的 [这个bug](https://stackoverflow.com/questions/16745988/sed-command-with-i-option-in-place-editing-works-fine-on-ubuntu-but-not-mac)

- `launch.json` 增加了在OSX上的 VSCode 运行调试的配置项

## 为将来可能增加的 README.md 的补充

### 在mac上编译与运行该项目，可能需要提前安装这些环境

- lua: `brew install lua`
- wget: `brew install wget`
- LuaRocks（[文档](https://luarocks.org/)）: 
```shell
wget https://luarocks.org/releases/luarocks-3.7.0.tar.gz
tar zxpf luarocks-3.7.0.tar.gz
cd luarocks-3.7.0
./configure && make && sudo make install
sudo luarocks install luasocket
```
- Yuescript Binary Tool（[文档](http://yuescript.org/doc/#an-overview-of-yuescript)）:
```
git clone git@github.com:pigpigyyy/Yuescript.git
cd Yuescript
make install
``` 
- Lua JIT（[文档](http://luajit.org/download.html)）:
```shell
git clone https://luajit.org/git/luajit.git
make && sudo make install
```
- love2d（[文档](https://love2d.org/wiki/Getting_Started)）: 
  - 在[官网](https://love2d.org/)下载安装包
  - 解压安装包，将解压出来的程序移动到 `/Applications` 目录
